### PR TITLE
Remove presets for specific build types

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -10,18 +10,21 @@ env:
   # Environment variables used by CMake.
   # See: https://cmake.org/cmake/help/latest/envvar/CMAKE_GENERATOR.html
   CMAKE_BUILD_TYPE: Release
-  CMAKE_GENERATOR: Ninja
   VERBOSE: ON
 
 jobs:
-  build:
+  ninja:
     strategy:
       matrix:
         # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#choosing-github-hosted-runners
         runner-id: [macos-latest, ubuntu-latest, windows-latest]
-        sil-clang-format-workflow: [ninja]
-        lib1-workflow: [ninja-static-dev, ninja-shared-dev]
-        exe-lib2-workflow: [ninja-static-dev, ninja-shared-dev]
+        lib1-workflow: [static-dev, shared-dev]
+        exe-lib2-workflow: [static-dev, shared-dev]
+
+    env:
+      # Environment variables used by CMake.
+      # See: https://cmake.org/cmake/help/latest/envvar/CMAKE_GENERATOR.html
+      CMAKE_GENERATOR: Ninja
 
     runs-on: ${{matrix.runner-id}}
 
@@ -55,9 +58,13 @@ jobs:
       working-directory: ${{github.workspace}}
       # https://stackoverflow.com/a/53380855/2252948
       run: |
-        ln -s "$(brew --prefix llvm)/bin/clang-format" "/usr/local/bin/clang-format" && \
-        ln -s "$(brew --prefix llvm)/bin/clang-tidy" "/usr/local/bin/clang-tidy" && \
-        ln -s "$(brew --prefix llvm)/bin/clang-apply-replacements" "/usr/local/bin/clang-apply-replacements"
+        echo "LLVM Brew prefix: $(brew --prefix llvm)" && \
+        echo "ls -l $(brew --prefix llvm):" && \
+        ls -l "$(brew --prefix llvm)" && \
+        echo "ls -l $(brew --prefix llvm)/bin:" && \
+        ls -l "$(brew --prefix llvm)/bin" && \
+        echo "Adding $(brew --prefix llvm)/bin to PATH" && \
+        echo "$(brew --prefix llvm)/bin" >> $GITHUB_PATH
 
     - uses: actions/checkout@v3
       with:
@@ -67,7 +74,7 @@ jobs:
 
     - name: SilClangFormat/Workflow
       working-directory: ${{github.workspace}}/repo/SilClangFormat
-      run: cmake --workflow --preset "${{matrix.sil-clang-format-workflow}}"
+      run: cmake --workflow --preset default
 
     - name: SilClangFormat/Install
       working-directory: ${{github.workspace}}/repo/SilClangFormat/build

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -7,8 +7,10 @@ on:
     branches: [ "main" ]
 
 env:
-  BUILD_TYPE: Release
-  # https://cmake.org/cmake/help/latest/envvar/VERBOSE.html
+  # Environment variables used by CMake.
+  # See: https://cmake.org/cmake/help/latest/envvar/CMAKE_GENERATOR.html
+  CMAKE_BUILD_TYPE: Release
+  CMAKE_GENERATOR: Ninja
   VERBOSE: ON
 
 jobs:
@@ -18,8 +20,8 @@ jobs:
         # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#choosing-github-hosted-runners
         runner-id: [macos-latest, ubuntu-latest, windows-latest]
         sil-clang-format-workflow: [ninja]
-        lib1-workflow: [ninja-release-static-dev, ninja-release-shared-dev]
-        exe-lib2-workflow: [ninja-release-static-dev, ninja-release-shared-dev]
+        lib1-workflow: [ninja-static-dev, ninja-shared-dev]
+        exe-lib2-workflow: [ninja-static-dev, ninja-shared-dev]
 
     runs-on: ${{matrix.runner-id}}
 

--- a/CMakePresetsBase.json
+++ b/CMakePresetsBase.json
@@ -6,9 +6,8 @@
 	},
 	"configurePresets": [
 		{
-			"name": "base-ninja",
+			"name": "base-default",
 			"hidden": true,
-			"generator": "Ninja",
 			"binaryDir": "${sourceDir}/build",
 			"installDir": "${sourceDir}/../install/",
 			"cacheVariables": {

--- a/CMakePresetsBase.json
+++ b/CMakePresetsBase.json
@@ -34,24 +34,6 @@
 			}
 		},
 		{
-			"name": "base-release",
-			"hidden": true,
-			"displayName": "Base Release Config",
-			"description": "Base Release configure with Ninja.",
-			"cacheVariables": {
-				"CMAKE_BUILD_TYPE": "Release"
-			}
-		},
-		{
-			"name": "base-debug",
-			"hidden": true,
-			"displayName": "Base Debug Config",
-			"description": "Base Debug configure with Ninja.",
-			"cacheVariables": {
-				"CMAKE_BUILD_TYPE": "Debug"
-			}
-		},
-		{
 			"name": "base-static",
 			"hidden": true,
 			"cacheVariables": {

--- a/README.md
+++ b/README.md
@@ -3,3 +3,30 @@
 Tests of making libraries and importing them in other CMake projects or
 targets.
 
+## How to use
+
+Requires CMake v3.25. If it such a version is not available on your system, you can download it and then point the `compile-and-run.sh` script to the directory where .
+
+```sh
+CMAKE_GENERATOR=<Specify Generator> \
+	CMAKE_BUILD_TYPE=<Specify build type> \
+    CMAKE_DIR=<path to CMake's dir if cmake is not in PATH; the CMake executable is "${CMAKE_DIR}/bin/cmake"> \
+    ./compile-and-run.sh
+```
+
+For example:
+
+```sh
+CMAKE_GENERATOR=Ninja \
+	CMAKE_BUILD_TYPE=Release \
+    ./compile-and-run.sh
+```
+
+### Multi-config generators
+
+Note that, at the moment, multi-config generators (e.g. `Visual Studio *`, `XCode`, ...) do not work with `compile-and-run.sh`. If you want to compile this project using a multi-config generator, you will have to figure out and specify the CMake flags manually without using `compile-and-run.sh`. To do that, try a single-config generator (e.g. Ninja) and look at the cache variables in `cmake-gui` or `ccmake`, or just look at the generated `CMakeCache.txt` directly.
+
+This is because one of this project's goals is to try out new and shiny CMake stuff, so `compile-and-run.sh` uses CMake's `CMakePresets.json` file to specify configure, build and test presets. In a normal context, this file is meant to be used interactively, not through a script, but, well, we really want to try out the new and shiny, so we want to build through that.
+
+Unfortunately, externally via an environment variable, we can't find a way to provide the config (Release/Debug/RelWithDebInfo/...) to build, test, and install, except maybe if we used CMake's [CMAKE_DEFAULT_BUILD_TYPE](https://cmake.org/cmake/help/latest/variable/CMAKE_DEFAULT_BUILD_TYPE.html#variable:CMAKE_DEFAULT_BUILD_TYPE) cache variable in the presets file and get that variable's value through an environement variable. However, even if we did that, it would only work with the `Ninja Multi-Config` generator because that cache variable is only used by that specific generator. So multi-config generators don't work with the `compile-and-run.sh` script right now.
+

--- a/SilClangFormat/CMakePresets.json
+++ b/SilClangFormat/CMakePresets.json
@@ -9,10 +9,10 @@
 	],
 	"configurePresets": [
 		{
-			"name": "ninja",
-			"displayName": "Ninja",
+			"name": "default",
+			"displayName": "Default",
 			"inherits": [
-				"base-ninja"
+				"base-default"
 			]
 		}
 	],
@@ -23,7 +23,7 @@
 			"inherits": [
 				"base-default"
 			],
-			"configurePreset": "ninja"
+			"configurePreset": "default"
 		}
 	],
 	"testPresets": [
@@ -33,17 +33,17 @@
 			"inherits": [
 				"base-default"
 			],
-			"configurePreset": "ninja"
+			"configurePreset": "default"
 		}
 	],
 	"workflowPresets": [
 		{
-			"name": "ninja",
-			"displayName": "Ninja",
+			"name": "default",
+			"displayName": "Default",
 			"steps": [
 				{
 					"type": "configure",
-					"name": "ninja"
+					"name": "default"
 				},
 				{
 					"type": "build",

--- a/compile-and-run.sh
+++ b/compile-and-run.sh
@@ -2,9 +2,9 @@
 # SPDX-License-Identifier: MIT
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
-SILCLANGFORMAT_WORKFLOW=ninja
-LIB1_WORKFLOW=ninja-shared
-LIB2EXE_WORKFLOW=ninja-shared
+SILCLANGFORMAT_WORKFLOW=default
+LIB1_WORKFLOW=shared
+LIB2EXE_WORKFLOW=shared
 
 big_message() {
 	echo
@@ -14,23 +14,51 @@ big_message() {
 	echo
 }
 
-echo "Assuming cmake command is \"${CMAKE_BIN_DIR}cmake\""
+set_cmake() {
+	if [ ! -z "${CMAKE_DIR}" ]; then
+		export CMAKE_CMD="${CMAKE_DIR}/bin/cmake"
+	else
+		export CMAKE_CMD="$(which cmake)"
+	fi
+	echo CMAKE_CMD: "$CMAKE_CMD"
+}
+
+# The CMakePresets.json files check the CMake version, however cmake itself
+# does not support the presets file until CMake 3.19.
+check_cmake_version() {
+	local min_major=3
+	local min_minor=19
+
+	local version_string="$("${CMAKE_CMD}" --version | grep -oP '(?<=^cmake version ).*')"
+	local major_number="$(echo "${version_string}" | grep -oP '^\d+(?=[\.$])')"
+	local minor_number="$(echo "${version_string}" | grep -oP '(?<=^'"${major_number}"'\.)\d+(?=[\.$])')"
+	if [ "${major_number}" -gt "${min_major}" ] || [ "${major_number}" -eq "${min_major}" ] && [ "${minor_number}" -ge "${min_minor}" ]; then
+		echo "OK, CMake version is ${version_string} >= ${min_major}.${min_minor}."
+	else
+		echo "ERROR, CMake version is ${version_string} which is less than the minimum required of ${min_major}.${min_minor}." >&2
+		exit 1
+	fi
+}
+
+set_cmake
+big_message "Assuming cmake command is \"${CMAKE_CMD}\""
+check_cmake_version
 
 cd "${SCRIPT_DIR}"
 
 rm -rf {SilClangFormat,lib1,exe-and-lib2}/build install
 big_message "SilClangFormat workflow ${SILCLANGFORMAT_WORKFLOW}"
 cd "${SCRIPT_DIR}"/SilClangFormat
-"${CMAKE_BIN_DIR}"cmake --workflow --preset "${SILCLANGFORMAT_WORKFLOW}"
-"${CMAKE_BIN_DIR}"cmake --install build
+"${CMAKE_CMD}" --workflow --preset "${SILCLANGFORMAT_WORKFLOW}"
+"${CMAKE_CMD}" --install build --config "${CMAKE_CONFIG_TYPE}"
 big_message "lib1 workflow ${LIB1_WORKFLOW}"
 cd "${SCRIPT_DIR}"/lib1
-"${CMAKE_BIN_DIR}"cmake --workflow --preset "${LIB1_WORKFLOW}"
-"${CMAKE_BIN_DIR}"cmake --install build
+"${CMAKE_CMD}" --workflow --preset "${LIB1_WORKFLOW}"
+"${CMAKE_CMD}" --install build --config "${CMAKE_CONFIG_TYPE}"
 big_message "exe-and-lib2 workflow ${LIB2EXE_WORKFLOW}"
 cd "${SCRIPT_DIR}"/exe-and-lib2
-"${CMAKE_BIN_DIR}"cmake --workflow --preset "${LIB2EXE_WORKFLOW}"
-"${CMAKE_BIN_DIR}"cmake --install build
+"${CMAKE_CMD}" --workflow --preset "${LIB2EXE_WORKFLOW}"
+"${CMAKE_CMD}" --install build --config "${CMAKE_CONFIG_TYPE}"
 big_message "Running executable"
 cd "${SCRIPT_DIR}"
 ./install/bin/exe

--- a/compile-and-run.sh
+++ b/compile-and-run.sh
@@ -3,8 +3,8 @@
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
 SILCLANGFORMAT_WORKFLOW=ninja
-LIB1_WORKFLOW=ninja-release-shared
-LIB2EXE_WORKFLOW=ninja-release-shared
+LIB1_WORKFLOW=ninja-shared
+LIB2EXE_WORKFLOW=ninja-shared
 
 big_message() {
 	echo

--- a/exe-and-lib2/CMakePresets.json
+++ b/exe-and-lib2/CMakePresets.json
@@ -20,256 +20,132 @@
 			}
 		},
 		{
-			"name": "ninja-release-static",
-			"inherits": ["base-ninja", "base-release", "base-static", "project-base"]
+			"name": "ninja-static",
+			"inherits": ["base-ninja", "base-static", "project-base"]
 		},
 		{
-			"name": "ninja-debug-static",
-			"inherits": ["base-ninja", "base-debug", "base-static", "project-base"]
+			"name": "ninja-shared",
+			"inherits": ["base-ninja", "base-shared", "project-base"]
 		},
 		{
-			"name": "ninja-release-shared",
-			"inherits": ["base-ninja", "base-release", "base-shared", "project-base"]
+			"name": "ninja-static-dev",
+			"inherits": ["ninja-static", "base-dev"]
 		},
 		{
-			"name": "ninja-debug-shared",
-			"inherits": ["base-ninja", "base-debug", "base-shared", "project-base"]
-		},
-		{
-			"name": "ninja-release-static-dev",
-			"inherits": ["ninja-release-static", "base-dev"]
-		},
-		{
-			"name": "ninja-debug-static-dev",
-			"inherits": ["ninja-debug-static", "base-dev"]
-		},
-		{
-			"name": "ninja-release-shared-dev",
-			"inherits": ["ninja-release-shared", "base-dev"]
-		},
-		{
-			"name": "ninja-debug-shared-dev",
-			"inherits": ["ninja-debug-shared", "base-dev"]
+			"name": "ninja-shared-dev",
+			"inherits": ["ninja-shared", "base-dev"]
 		}
 	],
 	"buildPresets": [
 		{
-			"name": "ninja-release-static",
+			"name": "ninja-static",
 			"inherits": ["base-default"],
-			"configurePreset": "ninja-release-static"
+			"configurePreset": "ninja-static"
 		},
 		{
-			"name": "ninja-debug-static",
+			"name": "ninja-shared",
 			"inherits": ["base-default"],
-			"configurePreset": "ninja-debug-static"
+			"configurePreset": "ninja-shared"
 		},
 		{
-			"name": "ninja-release-shared",
+			"name": "ninja-static-dev",
 			"inherits": ["base-default"],
-			"configurePreset": "ninja-release-shared"
+			"configurePreset": "ninja-static-dev"
 		},
 		{
-			"name": "ninja-debug-shared",
+			"name": "ninja-shared-dev",
 			"inherits": ["base-default"],
-			"configurePreset": "ninja-debug-shared"
-		},
-		{
-			"name": "ninja-release-static-dev",
-			"inherits": ["base-default"],
-			"configurePreset": "ninja-release-static-dev"
-		},
-		{
-			"name": "ninja-debug-static-dev",
-			"inherits": ["base-default"],
-			"configurePreset": "ninja-debug-static-dev"
-		},
-		{
-			"name": "ninja-release-shared-dev",
-			"inherits": ["base-default"],
-			"configurePreset": "ninja-release-shared-dev"
-		},
-		{
-			"name": "ninja-debug-shared-dev",
-			"inherits": ["base-default"],
-			"configurePreset": "ninja-debug-shared-dev"
+			"configurePreset": "ninja-shared-dev"
 		}
 	],
 	"testPresets": [
 		{
-			"name": "ninja-release-static",
+			"name": "ninja-static",
 			"inherits": ["base-default"],
-			"configurePreset": "ninja-release-static"
+			"configurePreset": "ninja-static"
 		},
 		{
-			"name": "ninja-debug-static",
+			"name": "ninja-shared",
 			"inherits": ["base-default"],
-			"configurePreset": "ninja-debug-static"
+			"configurePreset": "ninja-shared"
 		},
 		{
-			"name": "ninja-release-shared",
+			"name": "ninja-static-dev",
 			"inherits": ["base-default"],
-			"configurePreset": "ninja-release-shared"
+			"configurePreset": "ninja-static-dev"
 		},
 		{
-			"name": "ninja-debug-shared",
+			"name": "ninja-shared-dev",
 			"inherits": ["base-default"],
-			"configurePreset": "ninja-debug-shared"
-		},
-		{
-			"name": "ninja-release-static-dev",
-			"inherits": ["base-default"],
-			"configurePreset": "ninja-release-static-dev"
-		},
-		{
-			"name": "ninja-debug-static-dev",
-			"inherits": ["base-default"],
-			"configurePreset": "ninja-debug-static-dev"
-		},
-		{
-			"name": "ninja-release-shared-dev",
-			"inherits": ["base-default"],
-			"configurePreset": "ninja-release-shared-dev"
-		},
-		{
-			"name": "ninja-debug-shared-dev",
-			"inherits": ["base-default"],
-			"configurePreset": "ninja-debug-shared-dev"
+			"configurePreset": "ninja-shared-dev"
 		}
 	],
 	"workflowPresets": [
 		{
-			"name": "ninja-release-static",
+			"name": "ninja-static",
 			"steps": [
 				{
 					"type": "configure",
-					"name": "ninja-release-static"
+					"name": "ninja-static"
 				},
 				{
 					"type": "build",
-					"name": "ninja-release-static"
+					"name": "ninja-static"
 				},
 				{
 					"type": "test",
-					"name": "ninja-release-static"
+					"name": "ninja-static"
 				}
 			]
 		},
 		{
-			"name": "ninja-debug-static",
+			"name": "ninja-shared",
 			"steps": [
 				{
 					"type": "configure",
-					"name": "ninja-debug-static"
+					"name": "ninja-shared"
 				},
 				{
 					"type": "build",
-					"name": "ninja-debug-static"
+					"name": "ninja-shared"
 				},
 				{
 					"type": "test",
-					"name": "ninja-debug-static"
+					"name": "ninja-shared"
 				}
 			]
 		},
 		{
-			"name": "ninja-release-shared",
+			"name": "ninja-static-dev",
 			"steps": [
 				{
 					"type": "configure",
-					"name": "ninja-release-shared"
+					"name": "ninja-static-dev"
 				},
 				{
 					"type": "build",
-					"name": "ninja-release-shared"
+					"name": "ninja-static-dev"
 				},
 				{
 					"type": "test",
-					"name": "ninja-release-shared"
+					"name": "ninja-static-dev"
 				}
 			]
 		},
 		{
-			"name": "ninja-debug-shared",
+			"name": "ninja-shared-dev",
 			"steps": [
 				{
 					"type": "configure",
-					"name": "ninja-debug-shared"
+					"name": "ninja-shared-dev"
 				},
 				{
 					"type": "build",
-					"name": "ninja-debug-shared"
+					"name": "ninja-shared-dev"
 				},
 				{
 					"type": "test",
-					"name": "ninja-debug-shared"
-				}
-			]
-		},
-		{
-			"name": "ninja-release-static-dev",
-			"steps": [
-				{
-					"type": "configure",
-					"name": "ninja-release-static-dev"
-				},
-				{
-					"type": "build",
-					"name": "ninja-release-static-dev"
-				},
-				{
-					"type": "test",
-					"name": "ninja-release-static-dev"
-				}
-			]
-		},
-		{
-			"name": "ninja-debug-static-dev",
-			"steps": [
-				{
-					"type": "configure",
-					"name": "ninja-debug-static-dev"
-				},
-				{
-					"type": "build",
-					"name": "ninja-debug-static-dev"
-				},
-				{
-					"type": "test",
-					"name": "ninja-debug-static-dev"
-				}
-			]
-		},
-		{
-			"name": "ninja-release-shared-dev",
-			"steps": [
-				{
-					"type": "configure",
-					"name": "ninja-release-shared-dev"
-				},
-				{
-					"type": "build",
-					"name": "ninja-release-shared-dev"
-				},
-				{
-					"type": "test",
-					"name": "ninja-release-shared-dev"
-				}
-			]
-		},
-		{
-			"name": "ninja-debug-shared-dev",
-			"steps": [
-				{
-					"type": "configure",
-					"name": "ninja-debug-shared-dev"
-				},
-				{
-					"type": "build",
-					"name": "ninja-debug-shared-dev"
-				},
-				{
-					"type": "test",
-					"name": "ninja-debug-shared-dev"
+					"name": "ninja-shared-dev"
 				}
 			]
 		}

--- a/exe-and-lib2/CMakePresets.json
+++ b/exe-and-lib2/CMakePresets.json
@@ -12,7 +12,6 @@
 			"name": "project-base",
 			"hidden": true,
 			"cacheVariables": {
-				"CMAKE_PREFIX_PATH": "${sourceDir}/../install",
 				"lib2_BUILD_WITH_PIC": {
 					"type": "BOOL",
 					"value": "ON"
@@ -20,132 +19,135 @@
 			}
 		},
 		{
-			"name": "ninja-static",
-			"inherits": ["base-ninja", "base-static", "project-base"]
+			"name": "static",
+			"inherits": ["base-default", "base-static", "project-base"],
+			"hidden": true
 		},
 		{
-			"name": "ninja-shared",
-			"inherits": ["base-ninja", "base-shared", "project-base"]
+			"name": "shared",
+			"inherits": ["base-default", "base-shared", "project-base"],
+			"hidden": true
+
 		},
 		{
-			"name": "ninja-static-dev",
-			"inherits": ["ninja-static", "base-dev"]
+			"name": "static-dev",
+			"inherits": ["static", "base-dev"]
 		},
 		{
-			"name": "ninja-shared-dev",
-			"inherits": ["ninja-shared", "base-dev"]
+			"name": "shared-dev",
+			"inherits": ["shared", "base-dev"]
 		}
 	],
 	"buildPresets": [
 		{
-			"name": "ninja-static",
+			"name": "static",
 			"inherits": ["base-default"],
-			"configurePreset": "ninja-static"
+			"configurePreset": "static"
 		},
 		{
-			"name": "ninja-shared",
+			"name": "shared",
 			"inherits": ["base-default"],
-			"configurePreset": "ninja-shared"
+			"configurePreset": "shared"
 		},
 		{
-			"name": "ninja-static-dev",
+			"name": "static-dev",
 			"inherits": ["base-default"],
-			"configurePreset": "ninja-static-dev"
+			"configurePreset": "static-dev"
 		},
 		{
-			"name": "ninja-shared-dev",
+			"name": "shared-dev",
 			"inherits": ["base-default"],
-			"configurePreset": "ninja-shared-dev"
+			"configurePreset": "shared-dev"
 		}
 	],
 	"testPresets": [
 		{
-			"name": "ninja-static",
+			"name": "static",
 			"inherits": ["base-default"],
-			"configurePreset": "ninja-static"
+			"configurePreset": "static"
 		},
 		{
-			"name": "ninja-shared",
+			"name": "shared",
 			"inherits": ["base-default"],
-			"configurePreset": "ninja-shared"
+			"configurePreset": "shared"
 		},
 		{
-			"name": "ninja-static-dev",
+			"name": "static-dev",
 			"inherits": ["base-default"],
-			"configurePreset": "ninja-static-dev"
+			"configurePreset": "static-dev"
 		},
 		{
-			"name": "ninja-shared-dev",
+			"name": "shared-dev",
 			"inherits": ["base-default"],
-			"configurePreset": "ninja-shared-dev"
+			"configurePreset": "shared-dev"
 		}
 	],
 	"workflowPresets": [
 		{
-			"name": "ninja-static",
+			"name": "static",
 			"steps": [
 				{
 					"type": "configure",
-					"name": "ninja-static"
+					"name": "static"
 				},
 				{
 					"type": "build",
-					"name": "ninja-static"
+					"name": "static"
 				},
 				{
 					"type": "test",
-					"name": "ninja-static"
+					"name": "static"
 				}
 			]
 		},
 		{
-			"name": "ninja-shared",
+			"name": "shared",
 			"steps": [
 				{
 					"type": "configure",
-					"name": "ninja-shared"
+					"name": "shared"
 				},
 				{
 					"type": "build",
-					"name": "ninja-shared"
+					"name": "shared"
 				},
 				{
 					"type": "test",
-					"name": "ninja-shared"
+					"name": "shared"
 				}
 			]
 		},
 		{
-			"name": "ninja-static-dev",
+			"name": "static-dev",
 			"steps": [
 				{
 					"type": "configure",
-					"name": "ninja-static-dev"
+					"name": "static-dev"
 				},
 				{
 					"type": "build",
-					"name": "ninja-static-dev"
+					"name": "static-dev"
 				},
 				{
 					"type": "test",
-					"name": "ninja-static-dev"
+					"name": "static-dev"
 				}
 			]
 		},
 		{
-			"name": "ninja-shared-dev",
+			"name": "shared-dev",
 			"steps": [
 				{
 					"type": "configure",
-					"name": "ninja-shared-dev"
+					"name": "shared-dev"
 				},
 				{
 					"type": "build",
-					"name": "ninja-shared-dev"
+					"name": "shared-dev"
 				},
 				{
 					"type": "test",
-					"name": "ninja-shared-dev"
+					"name": "shared-dev"
 				}
 			]
 		}

--- a/lib1/CMakePresets.json
+++ b/lib1/CMakePresets.json
@@ -19,320 +19,164 @@
 			}
 		},
 		{
-			"name": "ninja-release-static",
-			"inherits": ["base-ninja", "base-release", "base-static", "project-base"],
-			"displayName": "Release Config Static",
-			"description": "Release configure with ninja with static libraries."
+			"name": "ninja-static",
+			"inherits": ["base-ninja", "base-static", "project-base"],
+			"displayName": "Config Static",
+			"description": "configure with ninja with static libraries."
 		},
 		{
-			"name": "ninja-debug-static",
-			"inherits": ["base-ninja", "base-debug", "base-static", "project-base"],
-			"displayName": "Debug Config Static",
-			"description": "Debug configure with ninja with static libraries."
+			"name": "ninja-shared",
+			"inherits": ["base-ninja", "base-shared", "project-base"],
+			"displayName": "Config Shared",
+			"description": "configure with ninja with shared libraries."
 		},
 		{
-			"name": "ninja-release-shared",
-			"inherits": ["base-ninja", "base-release", "base-shared", "project-base"],
-			"displayName": "Release Config Shared",
-			"description": "Release configure with ninja with shared libraries."
+			"name": "ninja-static-dev",
+			"inherits": ["ninja-static", "base-dev"],
+			"displayName": "Config Static Dev/CI",
+			"description": "configure with ninja with static libraries for dev/CI setup."
 		},
 		{
-			"name": "ninja-debug-shared",
-			"inherits": ["base-ninja", "base-debug", "base-shared", "project-base"],
-			"displayName": "Debug Config Shared",
-			"description": "Debug configure with ninja with shared libraries."
-		},
-		{
-			"name": "ninja-release-static-dev",
-			"inherits": ["ninja-release-static", "base-dev"],
-			"displayName": "Release Config Static Dev/CI",
-			"description": "Release configure with ninja with static libraries for dev/CI setup."
-		},
-		{
-			"name": "ninja-debug-static-dev",
-			"inherits": ["ninja-debug-static", "base-dev"],
-			"displayName": "Debug Config Static Dev/CI",
-			"description": "Debug configure with ninja with static libraries for dev/CI setup."
-		},
-		{
-			"name": "ninja-release-shared-dev",
-			"inherits": ["ninja-release-shared", "base-dev"],
-			"displayName": "Release Config Shared Dev/CI",
-			"description": "Release configure with ninja with shared libraries for dev/CI setup."
-		},
-		{
-			"name": "ninja-debug-shared-dev",
-			"inherits": ["ninja-debug-shared", "base-dev"],
-			"displayName": "Debug Config Shared Dev/CI",
-			"description": "Debug configure with ninja with shared libraries for dev/CI setup."
+			"name": "ninja-shared-dev",
+			"inherits": ["ninja-shared", "base-dev"],
+			"displayName": "Config Shared Dev/CI",
+			"description": "configure with ninja with shared libraries for dev/CI setup."
 		}
 	],
 	"buildPresets": [
 		{
-			"name": "ninja-release-static",
+			"name": "ninja-static",
 			"inherits": ["base-default"],
-			"configurePreset": "ninja-release-static",
-			"displayName": "Ninja Release Static",
-			"description": "Release with ninja with static libraries."
+			"configurePreset": "ninja-static",
+			"displayName": "Ninja Static",
+			"description": "With ninja with static libraries."
 		},
 		{
-			"name": "ninja-debug-static",
+			"name": "ninja-shared",
 			"inherits": ["base-default"],
-			"configurePreset": "ninja-debug-static",
-			"displayName": "Ninja Debug Static",
-			"description": "Debug with ninja with static libraries."
+			"configurePreset": "ninja-shared",
+			"displayName": "Ninja Shared",
+			"description": "With ninja with shared libraries."
 		},
 		{
-			"name": "ninja-release-shared",
+			"name": "ninja-static-dev",
 			"inherits": ["base-default"],
-			"configurePreset": "ninja-release-shared",
-			"displayName": "Ninja Release Shared",
-			"description": "Release with ninja with shared libraries."
+			"configurePreset": "ninja-static-dev",
+			"displayName": "Ninja Static Dev/CI",
+			"description": "With ninja with static libraries."
 		},
 		{
-			"name": "ninja-debug-shared",
+			"name": "ninja-shared-dev",
 			"inherits": ["base-default"],
-			"configurePreset": "ninja-debug-shared",
-			"displayName": "Ninja Debug Shared",
-			"description": "Debug with ninja with shared libraries."
-		},
-		{
-			"name": "ninja-release-static-dev",
-			"inherits": ["base-default"],
-			"configurePreset": "ninja-release-static-dev",
-			"displayName": "Ninja Release Static Dev/CI",
-			"description": "Release with ninja with static libraries."
-		},
-		{
-			"name": "ninja-debug-static-dev",
-			"inherits": ["base-default"],
-			"configurePreset": "ninja-debug-static-dev",
-			"displayName": "Ninja Debug Static Dev/CI",
-			"description": "Debug with ninja with static libraries."
-		},
-		{
-			"name": "ninja-release-shared-dev",
-			"inherits": ["base-default"],
-			"configurePreset": "ninja-release-shared-dev",
-			"displayName": "Ninja Release Shared Dev/CI",
-			"description": "Release with ninja with shared libraries."
-		},
-		{
-			"name": "ninja-debug-shared-dev",
-			"inherits": ["base-default"],
-			"configurePreset": "ninja-debug-shared-dev",
-			"displayName": "Ninja Debug Shared Dev/CI",
-			"description": "Debug with ninja with shared libraries."
+			"configurePreset": "ninja-shared-dev",
+			"displayName": "Ninja Shared Dev/CI",
+			"description": "With ninja with shared libraries."
 		}
 	],
 	"testPresets": [
 		{
-			"name": "ninja-release-static",
+			"name": "ninja-static",
 			"inherits": ["base-default"],
-			"configurePreset": "ninja-release-static",
-			"displayName": "Ninja Release Static",
-			"description": "Release with ninja with static libraries."
+			"configurePreset": "ninja-static",
+			"displayName": "Ninja Static",
+			"description": "With ninja with static libraries."
 		},
 		{
-			"name": "ninja-debug-static",
+			"name": "ninja-shared",
 			"inherits": ["base-default"],
-			"configurePreset": "ninja-debug-static",
-			"displayName": "Ninja Debug Static",
-			"description": "Debug with ninja with static libraries."
+			"configurePreset": "ninja-shared",
+			"displayName": "Ninja Shared",
+			"description": "With ninja with shared libraries."
 		},
 		{
-			"name": "ninja-release-shared",
+			"name": "ninja-static-dev",
 			"inherits": ["base-default"],
-			"configurePreset": "ninja-release-shared",
-			"displayName": "Ninja Release Shared",
-			"description": "Release with ninja with shared libraries."
+			"configurePreset": "ninja-static-dev",
+			"displayName": "Ninja Static Dev/CI",
+			"description": "With ninja with static libraries."
 		},
 		{
-			"name": "ninja-debug-shared",
+			"name": "ninja-shared-dev",
 			"inherits": ["base-default"],
-			"configurePreset": "ninja-debug-shared",
-			"displayName": "Ninja Debug Shared",
-			"description": "Debug with ninja with shared libraries."
-		},
-		{
-			"name": "ninja-release-static-dev",
-			"inherits": ["base-default"],
-			"configurePreset": "ninja-release-static-dev",
-			"displayName": "Ninja Release Static Dev/CI",
-			"description": "Release with ninja with static libraries."
-		},
-		{
-			"name": "ninja-debug-static-dev",
-			"inherits": ["base-default"],
-			"configurePreset": "ninja-debug-static-dev",
-			"displayName": "Ninja Debug Static Dev/CI",
-			"description": "Debug with ninja with static libraries."
-		},
-		{
-			"name": "ninja-release-shared-dev",
-			"inherits": ["base-default"],
-			"configurePreset": "ninja-release-shared-dev",
-			"displayName": "Ninja Release Shared Dev/CI",
-			"description": "Release with ninja with shared libraries."
-		},
-		{
-			"name": "ninja-debug-shared-dev",
-			"inherits": ["base-default"],
-			"configurePreset": "ninja-debug-shared-dev",
-			"displayName": "Ninja Debug Shared Dev/CI",
-			"description": "Debug with ninja with shared libraries."
+			"configurePreset": "ninja-shared-dev",
+			"displayName": "Ninja Shared Dev/CI",
+			"description": "With ninja with shared libraries."
 		}
 	],
 	"workflowPresets": [
 		{
-			"name": "ninja-release-static",
-			"displayName": "Ninja Release Static",
-			"description": "Release with ninja with static libraries.",
+			"name": "ninja-static",
+			"displayName": "Ninja Static",
+			"description": "With ninja with static libraries.",
 			"steps": [
 				{
 					"type": "configure",
-					"name": "ninja-release-static"
+					"name": "ninja-static"
 				},
 				{
 					"type": "build",
-					"name": "ninja-release-static"
+					"name": "ninja-static"
 				},
 				{
 					"type": "test",
-					"name": "ninja-release-static"
+					"name": "ninja-static"
 				}
 			]
 		},
 		{
-			"name": "ninja-debug-static",
-			"displayName": "Ninja Debug Static",
-			"description": "Debug with ninja with static libraries.",
+			"name": "ninja-shared",
+			"displayName": "Ninja Shared",
+			"description": "With ninja with shared libraries.",
 			"steps": [
 				{
 					"type": "configure",
-					"name": "ninja-debug-static"
+					"name": "ninja-shared"
 				},
 				{
 					"type": "build",
-					"name": "ninja-debug-static"
+					"name": "ninja-shared"
 				},
 				{
 					"type": "test",
-					"name": "ninja-debug-static"
+					"name": "ninja-shared"
 				}
 			]
 		},
 		{
-			"name": "ninja-release-shared",
-			"displayName": "Ninja Release Shared",
-			"description": "Release with ninja with shared libraries.",
+			"name": "ninja-static-dev",
+			"displayName": "Ninja Static Dev/CI",
+			"description": "With ninja with static libraries.",
 			"steps": [
 				{
 					"type": "configure",
-					"name": "ninja-release-shared"
+					"name": "ninja-static-dev"
 				},
 				{
 					"type": "build",
-					"name": "ninja-release-shared"
+					"name": "ninja-static-dev"
 				},
 				{
 					"type": "test",
-					"name": "ninja-release-shared"
+					"name": "ninja-static-dev"
 				}
 			]
 		},
 		{
-			"name": "ninja-debug-shared",
-			"displayName": "Ninja Debug Shared",
-			"description": "Debug with ninja with shared libraries.",
+			"name": "ninja-shared-dev",
+			"displayName": "Ninja Shared Dev/CI",
+			"description": "With ninja with shared libraries.",
 			"steps": [
 				{
 					"type": "configure",
-					"name": "ninja-debug-shared"
+					"name": "ninja-shared-dev"
 				},
 				{
 					"type": "build",
-					"name": "ninja-debug-shared"
+					"name": "ninja-shared-dev"
 				},
 				{
 					"type": "test",
-					"name": "ninja-debug-shared"
-				}
-			]
-		},
-		{
-			"name": "ninja-release-static-dev",
-			"displayName": "Ninja Release Static Dev/CI",
-			"description": "Release with ninja with static libraries.",
-			"steps": [
-				{
-					"type": "configure",
-					"name": "ninja-release-static-dev"
-				},
-				{
-					"type": "build",
-					"name": "ninja-release-static-dev"
-				},
-				{
-					"type": "test",
-					"name": "ninja-release-static-dev"
-				}
-			]
-		},
-		{
-			"name": "ninja-debug-static-dev",
-			"displayName": "Ninja Debug Static Dev/CI",
-			"description": "Debug with ninja with static libraries.",
-			"steps": [
-				{
-					"type": "configure",
-					"name": "ninja-debug-static-dev"
-				},
-				{
-					"type": "build",
-					"name": "ninja-debug-static-dev"
-				},
-				{
-					"type": "test",
-					"name": "ninja-debug-static-dev"
-				}
-			]
-		},
-		{
-			"name": "ninja-release-shared-dev",
-			"displayName": "Ninja Release Shared Dev/CI",
-			"description": "Release with ninja with shared libraries.",
-			"steps": [
-				{
-					"type": "configure",
-					"name": "ninja-release-shared-dev"
-				},
-				{
-					"type": "build",
-					"name": "ninja-release-shared-dev"
-				},
-				{
-					"type": "test",
-					"name": "ninja-release-shared-dev"
-				}
-			]
-		},
-		{
-			"name": "ninja-debug-shared-dev",
-			"displayName": "Ninja Debug Shared Dev/CI",
-			"description": "Debug with ninja with shared libraries.",
-			"steps": [
-				{
-					"type": "configure",
-					"name": "ninja-debug-shared-dev"
-				},
-				{
-					"type": "build",
-					"name": "ninja-debug-shared-dev"
-				},
-				{
-					"type": "test",
-					"name": "ninja-debug-shared-dev"
+					"name": "ninja-shared-dev"
 				}
 			]
 		}

--- a/lib1/CMakePresets.json
+++ b/lib1/CMakePresets.json
@@ -19,164 +19,150 @@
 			}
 		},
 		{
-			"name": "ninja-static",
-			"inherits": ["base-ninja", "base-static", "project-base"],
+			"name": "static",
+			"inherits": ["base-default", "base-static", "project-base"],
 			"displayName": "Config Static",
-			"description": "configure with ninja with static libraries."
+			"hidden": true
 		},
 		{
-			"name": "ninja-shared",
-			"inherits": ["base-ninja", "base-shared", "project-base"],
+			"name": "shared",
+			"inherits": ["base-default", "base-shared", "project-base"],
 			"displayName": "Config Shared",
-			"description": "configure with ninja with shared libraries."
+			"hidden": true
 		},
 		{
-			"name": "ninja-static-dev",
-			"inherits": ["ninja-static", "base-dev"],
-			"displayName": "Config Static Dev/CI",
-			"description": "configure with ninja with static libraries for dev/CI setup."
+			"name": "static-dev",
+			"inherits": ["static", "base-dev"],
+			"displayName": "Config Static Dev/CI"
 		},
 		{
-			"name": "ninja-shared-dev",
-			"inherits": ["ninja-shared", "base-dev"],
-			"displayName": "Config Shared Dev/CI",
-			"description": "configure with ninja with shared libraries for dev/CI setup."
+			"name": "shared-dev",
+			"inherits": ["shared", "base-dev"],
+			"displayName": "Config Shared Dev/CI"
 		}
 	],
 	"buildPresets": [
 		{
-			"name": "ninja-static",
+			"name": "static",
 			"inherits": ["base-default"],
-			"configurePreset": "ninja-static",
-			"displayName": "Ninja Static",
-			"description": "With ninja with static libraries."
+			"configurePreset": "static",
+			"displayName": "Static"
 		},
 		{
-			"name": "ninja-shared",
+			"name": "shared",
 			"inherits": ["base-default"],
-			"configurePreset": "ninja-shared",
-			"displayName": "Ninja Shared",
-			"description": "With ninja with shared libraries."
+			"configurePreset": "shared",
+			"displayName": "Shared"
 		},
 		{
-			"name": "ninja-static-dev",
+			"name": "static-dev",
 			"inherits": ["base-default"],
-			"configurePreset": "ninja-static-dev",
-			"displayName": "Ninja Static Dev/CI",
-			"description": "With ninja with static libraries."
+			"configurePreset": "static-dev",
+			"displayName": "Static Dev/CI"
 		},
 		{
-			"name": "ninja-shared-dev",
+			"name": "shared-dev",
 			"inherits": ["base-default"],
-			"configurePreset": "ninja-shared-dev",
-			"displayName": "Ninja Shared Dev/CI",
-			"description": "With ninja with shared libraries."
+			"configurePreset": "shared-dev",
+			"displayName": "Shared Dev/CI"
 		}
 	],
 	"testPresets": [
 		{
-			"name": "ninja-static",
+			"name": "static",
 			"inherits": ["base-default"],
-			"configurePreset": "ninja-static",
-			"displayName": "Ninja Static",
-			"description": "With ninja with static libraries."
+			"configurePreset": "static",
+			"displayName": "Static"
 		},
 		{
-			"name": "ninja-shared",
+			"name": "shared",
 			"inherits": ["base-default"],
-			"configurePreset": "ninja-shared",
-			"displayName": "Ninja Shared",
-			"description": "With ninja with shared libraries."
+			"configurePreset": "shared",
+			"displayName": "Shared"
 		},
 		{
-			"name": "ninja-static-dev",
+			"name": "static-dev",
 			"inherits": ["base-default"],
-			"configurePreset": "ninja-static-dev",
-			"displayName": "Ninja Static Dev/CI",
-			"description": "With ninja with static libraries."
+			"configurePreset": "static-dev",
+			"displayName": "Static Dev/CI"
 		},
 		{
-			"name": "ninja-shared-dev",
+			"name": "shared-dev",
 			"inherits": ["base-default"],
-			"configurePreset": "ninja-shared-dev",
-			"displayName": "Ninja Shared Dev/CI",
-			"description": "With ninja with shared libraries."
+			"configurePreset": "shared-dev",
+			"displayName": "Shared Dev/CI"
 		}
 	],
 	"workflowPresets": [
 		{
-			"name": "ninja-static",
-			"displayName": "Ninja Static",
-			"description": "With ninja with static libraries.",
+			"name": "static",
+			"displayName": "Static",
 			"steps": [
 				{
 					"type": "configure",
-					"name": "ninja-static"
+					"name": "static"
 				},
 				{
 					"type": "build",
-					"name": "ninja-static"
+					"name": "static"
 				},
 				{
 					"type": "test",
-					"name": "ninja-static"
+					"name": "static"
 				}
 			]
 		},
 		{
-			"name": "ninja-shared",
-			"displayName": "Ninja Shared",
-			"description": "With ninja with shared libraries.",
+			"name": "shared",
+			"displayName": "Shared",
 			"steps": [
 				{
 					"type": "configure",
-					"name": "ninja-shared"
+					"name": "shared"
 				},
 				{
 					"type": "build",
-					"name": "ninja-shared"
+					"name": "shared"
 				},
 				{
 					"type": "test",
-					"name": "ninja-shared"
+					"name": "shared"
 				}
 			]
 		},
 		{
-			"name": "ninja-static-dev",
-			"displayName": "Ninja Static Dev/CI",
-			"description": "With ninja with static libraries.",
+			"name": "static-dev",
+			"displayName": "Static Dev/CI",
 			"steps": [
 				{
 					"type": "configure",
-					"name": "ninja-static-dev"
+					"name": "static-dev"
 				},
 				{
 					"type": "build",
-					"name": "ninja-static-dev"
+					"name": "static-dev"
 				},
 				{
 					"type": "test",
-					"name": "ninja-static-dev"
+					"name": "static-dev"
 				}
 			]
 		},
 		{
-			"name": "ninja-shared-dev",
-			"displayName": "Ninja Shared Dev/CI",
-			"description": "With ninja with shared libraries.",
+			"name": "shared-dev",
+			"displayName": "Shared Dev/CI",
 			"steps": [
 				{
 					"type": "configure",
-					"name": "ninja-shared-dev"
+					"name": "shared-dev"
 				},
 				{
 					"type": "build",
-					"name": "ninja-shared-dev"
+					"name": "shared-dev"
 				},
 				{
 					"type": "test",
-					"name": "ninja-shared-dev"
+					"name": "shared-dev"
 				}
 			]
 		}


### PR DESCRIPTION
The build type should be specified as an environement variable instead to prevent having an overwhelming number of presets.