### PR TITLE
Replace 'copy' with 'copy -t' for DLL copies

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ sudo apt install clang-format-16 clang-tidy-16
 ```
 
 - Actual dependencies:
-    - CMake >= 3.25. If such a version is not available on your system, you can [download/install it here](https://cmake.org/download/).
+    - CMake >= 3.26. If such a version is not available on your system, you can [download/install it here](https://cmake.org/download/).
     - A generator supported by CMake (such as `ninja` or `make`).
     - (Optional) `clang-tidy` and `clang-format` version >= 16. Only needed by the `static-dev` and `shared-dev` configure presets.
 

--- a/prj1/CMakeLists.txt
+++ b/prj1/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 
-cmake_minimum_required(VERSION 3.25)
+cmake_minimum_required(VERSION 3.26)
 
 # This is required to be before the first project() call of the CMake build.
 set(CMAKE_TOOLCHAIN_FILE

--- a/prj1/test/CMakeLists.txt
+++ b/prj1/test/CMakeLists.txt
@@ -45,18 +45,15 @@ target_link_libraries(lib1_test
 # The executable needs to have any DLLs in its directory in order to run, so
 # copy them. Note that this copies them to the *binary directory*, not the
 # final installation.
-#
-# TODO The GitHub actions don't have CMake 3.26 yet, which would allow the
-# command 'cmake -E copy -t <dir> <files>...' that supports the '<files>...'
-# being empty (such as on non-Win32).
-if (WIN32)
-  add_custom_command(
-	TARGET lib1_test POST_BUILD
-	COMMAND ${CMAKE_COMMAND} -E copy
-      $<TARGET_RUNTIME_DLLS:lib1_test> $<TARGET_FILE_DIR:lib1_test>
-	COMMAND_EXPAND_LISTS
-  )
-endif()
+add_custom_command(
+  TARGET lib1_test POST_BUILD
+  # Using the CMake 3.26 'copy -t', which supports copying no files. It was
+  # added specifically to support copying DLLs:
+  # https://gitlab.kitware.com/cmake/cmake/-/issues/23543
+  COMMAND ${CMAKE_COMMAND} -E copy -t
+    $<TARGET_FILE_DIR:lib1_test> $<TARGET_RUNTIME_DLLS:lib1_test>
+  COMMAND_EXPAND_LISTS
+)
 
 include(GoogleTest)
 # Creates a task that will query the test executable (<exe> --gtest_list_tests)

--- a/prj2/CMakeLists.txt
+++ b/prj2/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 
-cmake_minimum_required(VERSION 3.25)
+cmake_minimum_required(VERSION 3.26)
 
 # This is required to be before the first project() call of the CMake build.
 set(CMAKE_TOOLCHAIN_FILE

--- a/prj2/exe/test/CMakeLists.txt
+++ b/prj2/exe/test/CMakeLists.txt
@@ -46,18 +46,15 @@ target_link_libraries(exe_test
 # The executable needs to have any DLLs in its directory in order to run, so
 # copy them. Note that this copies them to the *binary directory*, not the
 # final installation.
-#
-# TODO The GitHub actions don't have CMake 3.26 yet, which would allow the
-# command 'cmake -E copy -t <dir> <files>...' that supports the '<files>...'
-# being empty (such as on non-Win32).
-if (WIN32)
-  add_custom_command(
-	TARGET exe_test POST_BUILD
-	COMMAND ${CMAKE_COMMAND} -E copy
-      $<TARGET_RUNTIME_DLLS:exe_test> $<TARGET_FILE_DIR:exe_test>
-	COMMAND_EXPAND_LISTS
-  )
-endif()
+add_custom_command(
+  TARGET exe_test POST_BUILD
+  # Using the CMake 3.26 'copy -t', which supports copying no files. It was
+  # added specifically to support copying DLLs:
+  # https://gitlab.kitware.com/cmake/cmake/-/issues/23543
+  COMMAND ${CMAKE_COMMAND} -E copy -t
+    $<TARGET_FILE_DIR:exe_test> $<TARGET_RUNTIME_DLLS:exe_test>
+  COMMAND_EXPAND_LISTS
+)
 
 include(GoogleTest)
 # Creates a task that will query the test executable (<exe> --gtest_list_tests)

--- a/prj2/lib2/test/CMakeLists.txt
+++ b/prj2/lib2/test/CMakeLists.txt
@@ -45,18 +45,15 @@ target_link_libraries(lib2_test
 # The executable needs to have any DLLs in its directory in order to run, so
 # copy them. Note that this copies them to the *binary directory*, not the
 # final installation.
-#
-# TODO The GitHub actions don't have CMake 3.26 yet, which would allow the
-# command 'cmake -E copy -t <dir> <files>...' that supports the '<files>...'
-# being empty (such as on non-Win32).
-if (WIN32)
-  add_custom_command(
-	TARGET lib2_test POST_BUILD
-	COMMAND ${CMAKE_COMMAND} -E copy
-      $<TARGET_RUNTIME_DLLS:lib2_test> $<TARGET_FILE_DIR:lib2_test>
-	COMMAND_EXPAND_LISTS
-  )
-endif()
+add_custom_command(
+  TARGET lib2_test POST_BUILD
+  # Using the CMake 3.26 'copy -t', which supports copying no files. It was
+  # added specifically to support copying DLLs:
+  # https://gitlab.kitware.com/cmake/cmake/-/issues/23543
+  COMMAND ${CMAKE_COMMAND} -E copy -t
+    $<TARGET_FILE_DIR:lib2_test> $<TARGET_RUNTIME_DLLS:lib2_test>
+  COMMAND_EXPAND_LISTS
+)
 
 include(GoogleTest)
 # Creates a task that will query the test executable (<exe> --gtest_list_tests)


### PR DESCRIPTION
GitHub Actions has CMake 3.26 now, which introduces 'copy -t'.