### PR TITLE
Stop running the vcpkg bootstrap script

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -254,11 +254,6 @@ jobs:
         # 'git submodule update --init --recursive')
         submodules: recursive
 
-    - name: Setup Vcpkg
-      working-directory: ${{github.workspace}}/repo
-      run: |
-        cmd /c vcpkg\bootstrap-vcpkg.bat
-
     - name: AdeClangFormat/Workflow
       working-directory: ${{github.workspace}}/repo/AdeClangFormat
       run: |
@@ -374,11 +369,6 @@ jobs:
         # Also clone submodules, recursively (like
         # 'git submodule update --init --recursive')
         submodules: recursive
-
-    - name: Setup Vcpkg
-      working-directory: ${{github.workspace}}/repo
-      run: |
-        cmd /c vcpkg\bootstrap-vcpkg.bat
 
     - name: AdeClangFormat/Workflow
       working-directory: ${{github.workspace}}/repo/AdeClangFormat

--- a/build-and-run.sh
+++ b/build-and-run.sh
@@ -17,7 +17,7 @@ check_cmake_version
 
 check_vcpkg
 # Nothing to do to install vcpkg packages; the packages will be installed
-# as part of the CMake build (I suppose as part of running the vcpkg toolchain
+# as part of the CMake build (likely as part of running the vcpkg toolchain
 # file).
 
 clean

--- a/doc/rationale.md
+++ b/doc/rationale.md
@@ -53,7 +53,6 @@ NOTE: Because this is a superproject, the orchestration of both CMake builds is 
 
 ```bash
 cd repo-dir && \
-./vcpkg/bootstrap-vcpkg.sh && \
 cmake -S . -B build --preset <configure-preset-name> && \
 cmake --build build -j10 && \
 ctest --test-dir build -j10 && \

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -202,25 +202,7 @@ check_vcpkg() {
 
 	export VCPKG_EXE="$VCPKG_DIR/vcpkg"
 
-	echo "Assuming vcpkg executable is \"$VCPKG_EXE\" and running vcpkg bootstrap."
-	if [ "$OS" == GNU/Linux ] || [ "$OS" == Darwin ]; then
-		local vcpkg_bootstrap="$VCPKG_DIR/bootstrap-vcpkg.sh"
-		run_or_print "${vcpkg_bootstrap}"
-	elif [ "$OS" == Msys ]; then
-		local vcpkg_bootstrap="$VCPKG_DIR/bootstrap-vcpkg.bat"
-		# 'cmd /c <cmd>' but since we're on an Msys shell, we need to add an
-		# extra '/' to '/c' so that the shell understands we aren't passing a
-		# file path that needs to be transformed into backslashes.
-		run_or_print cmd //c "${vcpkg_bootstrap}"
-	else
-		echo "Unexpected platform \"$OS\"." >&2
-		exit 1
-	fi
-
-	if [ "$IS_DRY_RUN" == 0 ] && ! "${VCPKG_EXE}" version; then
-		echo "vcpkg executable does not exist or does not work." >&2
-		exit 1
-	fi
+	echo "Assuming vcpkg executable is \"$VCPKG_EXE\"."
 
 	if [ ! -d vcpkg ]; then
 		# Do not run the git command here: it is frequent to produce tarballs


### PR DESCRIPTION
We found out it is unnecessary with vcpkg manifest mode.